### PR TITLE
Adds execute permission to service executables

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -1,4 +1,6 @@
 FROM ruby:2.1-onbuild
 EXPOSE 4567
 
+RUN chmod u+x ./portal.rb
+
 CMD ["./portal.rb"]

--- a/stock-price/Dockerfile
+++ b/stock-price/Dockerfile
@@ -1,4 +1,6 @@
 FROM ruby:2.1-onbuild
 EXPOSE 4567
 
+RUN chmod u+x ./stocks.rb
+
 CMD ["./stocks.rb"]

--- a/weather/Dockerfile
+++ b/weather/Dockerfile
@@ -1,4 +1,6 @@
 FROM ruby:2.1-onbuild
 EXPOSE 4567
 
+RUN chmod u+x ./weather.rb
+
 CMD ["./weather.rb"]


### PR DESCRIPTION
### Problem

Whilst following the blog post on [using Consul with ECS](https://aws.amazon.com/blogs/compute/service-discovery-via-consul-with-amazon-ecs/) I found that the containers wouldn't start with the following error for each of them, for example the stocks service:

``` bash
Status reason:  DockerStateError: [8] System error: exec: "./stocks.rb": permission denied
```
### Solution

I thought about just changing the execute permissions in the git repo but it seemed a safer bet to do it whilst building the image as you're never aware of what OS or what the user has done outside of the build process to the repo hosing the executable.
