### PR TITLE
Fixed: Registrator was registering with wrong IP

### DIFF
--- a/service-discovery-blog-template
+++ b/service-discovery-blog-template
@@ -897,7 +897,8 @@
                                         [
                                             "docker run -d --restart=always -v /var/run/docker.sock:/tmp/docker.sock",
                                             " -h $(curl -s http://169.254.169.254/latest/meta-data/instance-id)",
-                                            " --name consul-registrator gliderlabs/registrator",
+                                            " --name consul-registrator gliderlabs/registrator:latest",
+                                            " -ip $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)",
                                             " consul://$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8500"
                                         ]
                                     ]


### PR DESCRIPTION
Registrator was registering with its own container IP instead of the local IP of the EC2 instance.
