### PR TITLE
Added APPID parameter to external API call

### DIFF
--- a/weather/weather.rb
+++ b/weather/weather.rb
@@ -2,17 +2,37 @@
 require 'sinatra'
 require 'net/http'
 require 'json'
+require 'logger'
 
 set :bind, '0.0.0.0'
 
-IS_METRIC = true
+# do the configuration of the web server
+configure do
+
+  enable :logging
+
+  # get the temperature scale from an enviornment variable
+  temp_scale = ENV['TEMP_SCALE']
+  case temp_scale
+  when 'C'
+    set :is_metric => true
+  when 'F'
+    set :is_metric => false
+  else
+    set :is_metric => true
+  end
+
+  # get the Open Weathermap API Key from an enviornment variable
+  set :api_key => ENV['API_KEY']
+end
+
 
 # The URI to do a temperature lookup for the specified city.
 # Returns a JSON document with city name, country and temperature.
 get '/weather/:city' do
   "Weather: #{params['city']}"
   result = lookup_weather(params['city'])
-  puts result
+  logger.info "Response from external API is: #{result}"
   convert_to_JSON(params['city'], result) if !result.nil?
 end
 
@@ -25,8 +45,9 @@ end
 # Makes a call to the Open Weather Map API and returns result
 def lookup_weather(city)
   uri = URI("http://api.openweathermap.org/data/2.5/weather")
-  params = { :q => city, :units => "metric" }
+  params = { :q => city, :units => (settings.is_metric ? "metric" : "imperial"), :APPID => settings.api_key }
   uri.query = URI.encode_www_form(params)
+  logger.info "URI is: #{uri}"
   res = Net::HTTP.get_response(uri)
   res.body if res.is_a?(Net::HTTPSuccess)
 end
@@ -37,7 +58,6 @@ def convert_to_JSON(city, response)
   result = {  :city => output['name'],
               :country => output['sys']['country'],
               :temp => output['main']['temp'],
-              :format => (IS_METRIC ? "Celcius" : "Farenheit") }
+              :format => (settings.is_metric ? "Celsius" : "Farenheit") }
   result.to_json
 end
-


### PR DESCRIPTION
I have updated the weather ruby code to include the required APPID parameter which needs to be a customer specific API_KEY. The API Key is passed in via Environment variable and also can change the temperature scale between Celsius and Fahrenheit. Also updated the way logging is done to output to the Sinatra logs.
