### PR TITLE
added ECS_RESERVED_MEMORY entry to ecs config

### DIFF
--- a/service-discovery-blog-template
+++ b/service-discovery-blog-template
@@ -773,7 +773,8 @@
                                             "ECS_CLUSTER=",
                                             {
                                                 "Ref": "EcsClusterName"
-                                            }
+                                            }, "\n",
+                                            "ECS_RESERVED_MEMORY=50"
                                         ]
                                     ]
                                 },


### PR DESCRIPTION
Added new parameter to ecs config file reserving 50 MB to consul and registrator containers so there are no out of memory issues on the ECS node
